### PR TITLE
updated node version for lambda

### DIFF
--- a/gitlab-runner.template
+++ b/gitlab-runner.template
@@ -301,7 +301,7 @@ Resources:
       Handler: index.handler
       MemorySize: 128
       Timeout: 15
-      Runtime: nodejs6.10
+      Runtime: nodejs12.x
       Role: !GetAtt 
         - RunnerUnregisterRole
         - Arn


### PR DESCRIPTION
When I deployed the template as it was I got the error below.
`
The  runtime parameter of nodejs6.10 is no longer supported for creating or  updating AWS Lambda functions. We recommend you use the new runtime  (nodejs12.x) while creating or updating functions. (Service:  AWSLambdaInternal; Status Code: 400; Error Code:  InvalidParameterValueException; Request ID:  95c7675a-1a77-4936-924e-02f0030884fb; Proxy: null)
--
`

Moving the node version to 12.x fixed the issue